### PR TITLE
feat: add rne as accepted document

### DIFF
--- a/enums/DocumentType.json
+++ b/enums/DocumentType.json
@@ -1,4 +1,5 @@
 {
   "rg": "RG - Registro Geral",
-  "cnh": "CNH - Carteira Nacional de Habilitação"
+  "cnh": "CNH - Carteira Nacional de Habilitação",
+  "rne": "RNE - Registro Nacional de Estrangeiro"
 }


### PR DESCRIPTION
This pull request adds a new document type to the `DocumentType` enum in `enums/DocumentType.json`.

* [`enums/DocumentType.json`](diffhunk://#diff-e24b8abe59ecd9fca0f73d9bd513be237aa194dc1d377087d6d71d16c060425fL3-R4): Introduced the `rne` document type with the description "RNE - Registro Nacional de Estrangeiro."